### PR TITLE
updated to work with new nda password encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ collection_3165_manifest_s3_links.csv
 derivative_subsets.txt
 src/__pycache__/
 
+.idea

--- a/src/nda_aws_token_generator.py
+++ b/src/nda_aws_token_generator.py
@@ -18,6 +18,7 @@ if sys.version_info[0] == 2:
 else:
     from urllib import request as urllib_request
 
+
 class NDATokenGenerator(object):
     __schemas = {
         'soap': 'http://schemas.xmlsoap.org/soap/envelope/',
@@ -31,13 +32,17 @@ class NDATokenGenerator(object):
 
     def generate_token(self, username, password):
         logging.info('request to generate AWS token')
-        encoded_password = self.__encode_password(password)
-        request_xml = self.__construct_request_xml(username, encoded_password)
-        return self.__make_request(request_xml)
+        try:
+            encoded_password = self.__encode_password(password)
+            request_xml = self.__construct_request_xml(username, encoded_password)
+            return self.__make_request(request_xml)
+        except:
+            encoded_password = self.__encode_password(password, hasher=hashlib.sha256())
+            request_xml = self.__construct_request_xml(username, encoded_password)
+            return self.__make_request(request_xml)
 
-    def __encode_password(self, password):
+    def __encode_password(self, password, hasher=hashlib.sha1()):
         logging.debug('encoding password')
-        hasher = hashlib.sha1()
         hasher.update(password.encode('utf-8'))
         digest_bytes = hasher.digest()
         byte_string = binascii.hexlify(digest_bytes)


### PR DESCRIPTION
A user opened a Help desk ticket stating that she was receiving a 401 error when using the nda-abcd-s3-downloader script. NDA has recently deployed a code update to start encoding passwords using sha256 based encoding. Some older passwords are still encrypted using sha1, so I updated the logic in the NDATokenGenerator class to try both encodings if the other one generates a 401.
The help desk user was able to use the script after these changes were applied to her local source copy of the nda-abcd-s3-downloader script.